### PR TITLE
Fixed .pxt playback on ARM devices, and fixed-up MakefileAlt

### DIFF
--- a/MakefileAlt
+++ b/MakefileAlt
@@ -27,7 +27,7 @@ MAIN += bladeThrow bubblePew fireballShoot machineGunShoot missileShoot nemesisS
 # bullet acts
 MAIN += blade bubbler fireball missile polarStar machineGun misc nemesis snake spur
 # npc acts
-MAIN += npcAct npc000 npc020 npc040 npc060 npc080 npc100 npc120 npc140 npc160 npc180 npc200 npc220 npc240 npc260 npc280 npc300 npc320 npc340
+MAIN += npcAct npc000 npc020 npc040 npc060 npc080 npc100 npc120 npc140 npc160 npc180 npc200 npc220 npc240 npc260 npc280 npc300 npc320 npc340 npc360
 # boss acts
 MAIN += balfrog core heavyPress monsterX omega
 

--- a/MakefileAlt
+++ b/MakefileAlt
@@ -3,7 +3,7 @@ WARNINGS = -pedantic -Wall -Wextra -Wno-multichar -Wno-unused-parameter
 CXXFLAGS = -O3 $(WARNINGS) -DUSE_ICONS_SDL2 -DLODEPNG_NO_COMPILE_ENCODER -DLODEPNG_NO_COMPILE_CPP
 ALL_CXXFLAGS = -std=c++17 `sdl2-config --cflags` -IJson_Modern_Cpp $(CXXFLAGS) -MMD -MP -MF $@.d
 LDFLAGS = -s
-ALL_LDFLAGS = -static `sdl2-config --static-libs` $(LDFLAGS)
+ALL_LDFLAGS = `sdl2-config --libs` $(LDFLAGS)
 LIBS = 
 ALL_LIBS = $(LIBS)
 

--- a/MakefileAlt.win
+++ b/MakefileAlt.win
@@ -27,7 +27,7 @@ MAIN += bladeThrow bubblePew fireballShoot machineGunShoot missileShoot nemesisS
 # bullet acts
 MAIN += blade bubbler fireball missile polarStar machineGun misc nemesis snake spur
 # npc acts
-MAIN += npcAct npc000 npc020 npc040 npc060 npc080 npc100 npc120 npc140 npc160 npc180 npc200 npc220 npc240 npc260 npc280 npc300 npc320 npc340
+MAIN += npcAct npc000 npc020 npc040 npc060 npc080 npc100 npc120 npc140 npc160 npc180 npc200 npc220 npc240 npc260 npc280 npc300 npc320 npc340 npc360
 # boss acts
 MAIN += balfrog core heavyPress monsterX omega
 

--- a/source/core.cpp
+++ b/source/core.cpp
@@ -1,3 +1,5 @@
+#include <string.h>
+
 #include "boss.h"
 #include "npc.h"
 #include "player.h"

--- a/source/monsterX.cpp
+++ b/source/monsterX.cpp
@@ -1,3 +1,5 @@
+#include <string.h>
+
 #include "npc.h"
 #include "boss.h"
 #include "game.h"

--- a/source/pxt.cpp
+++ b/source/pxt.cpp
@@ -216,7 +216,7 @@ int makePixelWaveData(const std::vector<long double>& pxtData, uint8_t *data)
 					+ 64)
 				/ 64)
 			/ 64
-			+ -128;
+			+ 128;	// This was originally -128, but casting a negative double to an unsigned char results in undefined behaviour
 
 		long double newMainOffset;
 		if (waveModelTable[(size_t)pxtData[6]][v2] >= 0)


### PR DESCRIPTION
I got a Raspberry Pi today, and figured I'd try to build this on it. It didn't go well.

The most glaring problem was that the .pxt files weren't playing properly. They'd just mute the rest of the audio. After hours of debugging (until 3 in the morning!!!), I found the cause: the PXT->PCM generator converts its output from signed 8-bit PCM to unsigned by subtracting 0x80 from it. Normally this is fine, but it would then try to store the result in an unsigned char.

As it turns out, [casting a negative float to an unsigned int invokes undefined behaviour](https://www.embeddeduse.com/2013/08/25/casting-a-negative-float-to-an-unsigned-int/). Suddenly, the audio becomes nothing but a bunch of 0s, which is why it mutes everything.

The solution is to just add 0x80 instead of subtract it. This moves the range from `-0x100 - 0` to `0 - 0x100`, which casts just fine.

Anyway, all that aside, there were some other issues I had while compiling this:

MakefileAlt tried to statically link everything, which isn't ideal on Linux. I must have accidentally copypasted it from the Windows makefile.

I also had a problem where GCC complained that two objects were using memcpy without including the right header. I'm not sure where this project keeps the standard headers, so I just put them at the top of the objects' .cpp files.

There's one more thing I didn't include in this pull request, but I thought might be worth bringing up: Raspbian only comes with GCC6, so at first I couldn't compile loadConfig.cpp because it was using cutting-edge C++17 features. I found a couple of ways to work around it, but I'm not sure if you want that cluttering the project.